### PR TITLE
add get-orders and update-orders

### DIFF
--- a/lib/dfp.js
+++ b/lib/dfp.js
@@ -458,6 +458,24 @@ Dfp.prototype.getAdUnit = function(conditions) {
 };
 
 /**
+ * Queries DFP to get all orders that match the string passed in.
+ * @param  {Object} conditions Properties used for querying. This object can
+ *                             include any properties that are valid PQL filters
+ *                             in DFP.
+ * @return {String}            The id of the order corresponding to the name
+ *                             passed in.
+ */
+Dfp.prototype.getOrders = function(conditions) {
+  var service = 'OrderService';
+  var method = 'getOrdersByStatement';
+
+  var query = _makeQuery(conditions, ORDER_FIELDS);
+
+    return this.dfpUser.executeAPIFunction(service, method, query)
+      .then(extractResults);
+};
+
+/**
  * Find the DFP id of the order passed in.
  *
  * @param  {Object} conditions Properties used for querying. This object can
@@ -466,7 +484,7 @@ Dfp.prototype.getAdUnit = function(conditions) {
  * @return {String}            The id of the order corresponding to the name
  *                             passed in.
  */
-Dfp.prototype.getOrder = function(conditions) {
+Dfp.prototype.getOrderId = function(conditions) {
   var service = 'OrderService';
   var method = 'getOrdersByStatement';
 
@@ -487,6 +505,36 @@ Dfp.prototype.getOrder = function(conditions) {
         });
     });
 };
+
+/**
+ * Sets up an alias to getOrderId to avoid breaking the API.
+ * @deprecated
+ */
+Dfp.prototype.getOrder = Dfp.prototype.getOrderId;
+
+/**
+ * Updates line items in DFP. Caution: archived line items cannot be updated and
+ * attempting to do so will throw an error. It is best to filter out archived
+ * line items before calling this method.
+ *
+ * @param  {Array} lineItems The line items with any updates already made.
+ * @return {Array}           Updated line items. Should be the same as what was
+ *                           passed it, with the addition of any fields created
+ *                           by DFP
+ */
+Dfp.prototype.updateOrders = function(orders) {
+  var input = {
+    'orders': orders
+  };
+
+  return this.dfpUser.executeAPIFunction(
+    'OrderService',
+    'updateOrders',
+    input
+  );
+};
+
+
 
 /**
  * Removes orderName in the passed in line item and adds the order id that


### PR DESCRIPTION
Adds two new methods:
- `getOrders`
- `updatesOrders`

Renames a method:
- `getOrder` => `getOrderId`
-  Makes `getOrder` an alias to avoid a breaking change.

I'd like to move all methods that fetch ids to use this same name convention, adding deprecated warnings to their old names and eventually remove them all in a major version bump.
# TODO
- [ ] Add tests for `getOrders`
- [ ] Add tests for  `updateOrders`
