### PR TITLE
Allow Paremeter to specify the config Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Go to the url and give authorization. Copy the auth code.
   ```
   $ node generate-refresh-token.js --authCode <auth code>
   ```
+  
+  If you are using this package as a dependency and local/config lives in your project you can pass the config path as an arguments as follow:
+  
+  ```
+    node node_modules/node-google-dfp-wrapper/generate-authentication-url.js --config $(pwd)'/local/application-creds'
+  node node_modules/node-google-dfp-wrapper/generate-refresh-token.js --config $(pwd)'/local/application-creds' --authCode <auth code>
+  ```
+  
 
 This will output a refresh token.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Go to the url and give authorization. Copy the auth code.
   $ node generate-refresh-token.js --authCode <auth code>
   ```
   
-  If you are using this package as a dependency and local/config lives in your project you can pass the config path as an arguments as follow:
+  If you are using this package as a dependency and local/application-creds lives in your project you can pass the config path as an arguments as follow:
   
   ```
     node node_modules/node-google-dfp-wrapper/generate-authentication-url.js --config $(pwd)'/local/application-creds'

--- a/generate-authentication-url.js
+++ b/generate-authentication-url.js
@@ -3,7 +3,9 @@
 // Generate authentication url.
 
 var google = require('googleapis');
-var DFP_CREDS = require('./local/application-creds');
+var argv = require('minimist')(process.argv.slice(2));
+var config = argv.config || './local/application-creds';
+var DFP_CREDS = require(config);
 
 var OAuth2 = google.auth.OAuth2;
 

--- a/generate-refresh-token.js
+++ b/generate-refresh-token.js
@@ -4,7 +4,8 @@ var google = require('googleapis');
 var Bluebird = require('bluebird');
 var OAuth2 = google.auth.OAuth2;
 var argv = require('minimist')(process.argv.slice(2));
-var DFP_CREDS = require('./local/application-creds');
+var config = argv.config || './local/application-creds';
+var DFP_CREDS = require(config);
 
 // Constants and arguments.
 var AUTH_CODE = argv.authCode;


### PR DESCRIPTION
Allows the auth url generator and refresk token generator to receive the PATH where the application-creds.json files are.

More info on the README, this will allow to add to spanishdict/example-dfp-line-item-generator the following npm scripts:

```
"authUrl": "node node_modules/node-google-dfp-wrapper/generate-authentication-url.js --config $(pwd)'/local/application-creds'",
    "refreshToken": "node node_modules/node-google-dfp-wrapper/generate-refresh-token.js --config $(pwd)'/local/application-creds'"
```

that we could be able to execute:

```
npm run authUrl
npm run refreshToken -- --authCode <auth code>
```