### PR TITLE
Chore add config path param

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Go to the url and give authorization. Copy the auth code.
   ```
   $ node generate-refresh-token.js --authCode <auth code>
   ```
+  
+  If you are using this package as a dependency and local/config lives in your project you can pass the config path as an arguments as follow:
+  
+  ```
+    node node_modules/node-google-dfp-wrapper/generate-authentication-url.js --config $(pwd)'/local/application-creds'
+  node node_modules/node-google-dfp-wrapper/generate-refresh-token.js --config $(pwd)'/local/application-creds' --authCode <auth code>
+  ```
+  
 
 This will output a refresh token.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Go to the url and give authorization. Copy the auth code.
   $ node generate-refresh-token.js --authCode <auth code>
   ```
   
-  If you are using this package as a dependency and local/config lives in your project you can pass the config path as an arguments as follow:
+  If you are using this package as a dependency and local/application-creds lives in your project you can pass the config path as an arguments as follow:
   
   ```
     node node_modules/node-google-dfp-wrapper/generate-authentication-url.js --config $(pwd)'/local/application-creds'

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To obtain your network code from DFP. It can be found in your url after you log 
 
 1. Run:
 
-  ```
+  ```bash
   $ cd node_modules/node-google-dfp-wrapper/
   $ node generate-authentication-url.js
   ```
@@ -57,17 +57,17 @@ Go to the url and give authorization. Copy the auth code.
 
 2. Run the script in "auth code" mode:
 
-  ```
+  ```bash
   $ node generate-refresh-token.js --authCode <auth code>
   ```
-  
+
   If you are using this package as a dependency and local/application-creds lives in your project you can pass the config path as an arguments as follow:
-  
+
+  ```bash
+  $ node node_modules/node-google-dfp-wrapper/generate-authentication-url.js --config $(pwd)'/local/application-creds'
+  $ node node_modules/node-google-dfp-wrapper/generate-refresh-token.js --config $(pwd)'/local/application-creds' --authCode <auth code>
   ```
-    node node_modules/node-google-dfp-wrapper/generate-authentication-url.js --config $(pwd)'/local/application-creds'
-  node node_modules/node-google-dfp-wrapper/generate-refresh-token.js --config $(pwd)'/local/application-creds' --authCode <auth code>
-  ```
-  
+
 
 This will output a refresh token.
 
@@ -98,4 +98,3 @@ This will output a refresh token.
   }
 }
 ```
-

--- a/generate-authentication-url.js
+++ b/generate-authentication-url.js
@@ -3,7 +3,9 @@
 // Generate authentication url.
 
 var google = require('googleapis');
-var DFP_CREDS = require('./local/application-creds');
+var argv = require('minimist')(process.argv.slice(2));
+var config = argv.config || './local/application-creds';
+var DFP_CREDS = require(config);
 
 var OAuth2 = google.auth.OAuth2;
 

--- a/generate-refresh-token.js
+++ b/generate-refresh-token.js
@@ -4,7 +4,8 @@ var google = require('googleapis');
 var Bluebird = require('bluebird');
 var OAuth2 = google.auth.OAuth2;
 var argv = require('minimist')(process.argv.slice(2));
-var DFP_CREDS = require('./local/application-creds');
+var config = argv.config || './local/application-creds';
+var DFP_CREDS = require(config);
 
 // Constants and arguments.
 var AUTH_CODE = argv.authCode;


### PR DESCRIPTION
@nanek 

Thanks to @ialex for your work on this! This makes it possible to specify a path to your credentials, that way if you are using `node-google-dfp-wrapper` as a dependency, you can call `generate-authentication-url.js` and `generate-refresh-token.js` from the root directory referencing credentials in `./local/`.
