### PR TITLE
Fixes _makeQuery to properly support id fields

### DIFF
--- a/lib/dfp.js
+++ b/lib/dfp.js
@@ -166,11 +166,23 @@ function _makeQuery(conditions, fields) {
   // build up 'Where' string
   var query = fields.reduce(function(condition, field) {
     var addition = '';
-    if (conditions[field]) {
+    var val = conditions[field];
+    var isNumber = typeof val === 'number';
+    if (val) {
       addition += field;
-      addition += ' like \'';
-      addition += conditions[field];
-      addition += '\' and ';
+      if (isNumber) {
+        addition += '=';
+      } else {
+        addition += ' like \'';
+      }
+
+      addition += val;
+
+      if (!isNumber) {
+        addition += '\'';
+      }
+
+      addition += ' and ';
     }
     return condition + addition;
   }, 'Where ');


### PR DESCRIPTION
We were running into an issue using custom criteria in which we were unable to look up value id's, as the DFP api was expecting the customCriteriaKeyId in our query to use an equal comparison, rather than a like.

I also think it'd be good to make sure any integers passed are exact comparisons, in the event you query for an integer and it returns a larger integer containing the digits passed in